### PR TITLE
Use https for node-cors-server on Heroku

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -1,6 +1,6 @@
 $(function(){
   var template = $('#template').html();
-  var baseUrl = 'http://node-cors-server.herokuapp.com';
+  var baseUrl = 'https://node-cors-server.herokuapp.com';
 
   if(/^http\:\/\/localhost/.test(window.location.href)){
     baseUrl = 'http://localhost:3000'; // for running/testing locally


### PR DESCRIPTION
In my browser, Heroku uses HTTPS by default, so this commit adjusts the `baseUrl` accordingly.

It results in this message being logged to the browser's console:

> Mixed Content: The page at 'https://node-cors-client.herokuapp.com/' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://node-cors-server.herokuapp.com/no-cors'. This request has been blocked; the content must be served over HTTPS.

In further testing, this appears to be because I use the HTTPS Everywhere addon for Chrome and it is choosing HTTPS for Heroku sites! So it's arguably due to a weird configuration I have, so I can live if you decide to not merge it.

However, I hope you still do merge it. The change is harmless for HTTP users of the site.
